### PR TITLE
[Bugfix] Floating point in editing cpt

### DIFF
--- a/src/validations/node.js
+++ b/src/validations/node.js
@@ -11,6 +11,8 @@ import {
   equals,
   all,
 } from 'ramda';
+import float from 'float';
+import { NODE_CPT_PRECISION } from 'constants/node';
 
 const isArray = is(Array);
 const isObject = is(Object);
@@ -36,7 +38,9 @@ export const hasStates = allPass([
 export const hasDescription = ({ showDescription, description }) =>
   Boolean(showDescription && description);
 
-const isSumValuesEqualsOne = pipe(sumValues, equalsOne);
+const formatFloatValue = value => float.round(value, NODE_CPT_PRECISION);
+
+const isSumValuesEqualsOne = pipe(sumValues, formatFloatValue, equalsOne);
 const isAllThenSumValuesEqualsOne = all(pipe(propThen, isSumValuesEqualsOne));
 
 export const isNodeCptValid = (cpt) => {

--- a/src/validations/node.test.js
+++ b/src/validations/node.test.js
@@ -110,6 +110,16 @@ describe('Node Validations', () => {
         it('returns truthy', () => {
           expect(isNodeCptValid(cpt)).toBeTruthy();
         });
+
+        describe('and contains floating point in the sum', () => {
+          it('returns truthy', () => {
+            expect(isNodeCptValid({
+              State1: 0.6,
+              State2: 0.3,
+              State3: 0.1,
+            })).toBeTruthy();
+          });
+        });
       });
 
       describe('and sum is not equals to one', () => {


### PR DESCRIPTION
The bug: 
<img width="392" alt="Screen Shot 2019-09-24 at 15 04 23" src="https://user-images.githubusercontent.com/2437673/65537981-bb6a7b80-dedc-11e9-82e0-2b46d107ab9d.png">


The validation was wrong because of floating point. It was fixed with `float` package.