### PR TITLE
Refactor nodes reducer

### DIFF
--- a/__fixtures__/networks/change-states/node-with-parents.json
+++ b/__fixtures__/networks/change-states/node-with-parents.json
@@ -40,8 +40,8 @@
           "Node 1": "True"
         },
         "then": {
-          "True": 0.75,
-          "New State": 0.25
+          "True": 0.5,
+          "New State": 0.5
         }
       },
       {
@@ -50,8 +50,8 @@
           "Node 1": "True"
         },
         "then": {
-          "True": 0.75,
-          "New State": 0.25
+          "True": 0.5,
+          "New State": 0.5
         }
       },
       {
@@ -60,8 +60,8 @@
           "Node 1": "False"
         },
         "then": {
-          "True": 0.75,
-          "New State": 0.25
+          "True": 0.5,
+          "New State": 0.5
         }
       },
       {
@@ -70,8 +70,8 @@
           "Node 1": "False"
         },
         "then": {
-          "True": 0.75,
-          "New State": 0.25
+          "True": 0.5,
+          "New State": 0.5
         }
       }
     ]

--- a/__fixtures__/networks/change-states/node-without-parents.json
+++ b/__fixtures__/networks/change-states/node-without-parents.json
@@ -7,8 +7,8 @@
     ],
     "parents": [],
     "cpt": {
-      "True": 0.75,
-      "New State": 0.25
+      "True": 0.5,
+      "New State": 0.5
     }
   },
   {

--- a/src/reducers/nodes.js
+++ b/src/reducers/nodes.js
@@ -1,4 +1,3 @@
-import { path } from 'ramda';
 import {
   ADD_NODE,
   ADD_PARENT,
@@ -9,348 +8,212 @@ import {
   REMOVE_NODE,
   REMOVE_PARENT,
 } from 'actions';
+import {
+  T,
+  allPass,
+  always,
+  any,
+  append,
+  applySpec,
+  assoc,
+  complement,
+  cond,
+  curry,
+  evolve,
+  identity,
+  ifElse,
+  map,
+  path,
+  pipe,
+  prop,
+  propEq,
+  useWith,
+} from 'ramda';
+import {
+  addNodeParent,
+  changeNodeParentName,
+  filterNodeParents,
+} from 'utils/node-parents';
+import {
+  addNodeParentInCpt,
+  createCpt,
+  removeNodeParentInCpt,
+  updateNodeParentIdInCpt,
+  updateNodeParentStatesInCpt,
+  updateStatesInCpt,
+} from 'utils/node-cpt';
+import { findNodeById, removeNodeById } from 'utils/node';
+
 import { SAVE_EDITING_NODE_CPT } from 'constants/editing-node-cpt';
 import { SAVE_EDITING_NODE_STATES } from 'constants/editing-node-states';
+import { containsParentInNode } from 'validations/node';
+import { hasCycleAddingNodeParent } from 'validations/network';
 
+const propId = prop('id');
+const propStates = prop('states');
 const pathPayloadCpt = path(['payload', 'cpt']);
+const pathPayloadParentId = path(['payload', 'parentId']);
+const pathPayloadStates = path(['payload', 'states']);
+const pathPayloadNextId = path(['payload', 'nextId']);
+const pathPayloadDescription = path(['payload', 'description']);
+const pathPayloadStateNodes = path(['payload', 'state', 'nodes']);
+const pathPayloadId = path(['payload', 'id']);
+const isNodeFromPayloadId = pipe(pathPayloadId, propEq('id'));
 
-const arrayEqual = (arr1, arr2) => {
-  if (arr1 === arr2) {
-    return true;
-  }
+const addParentValidation = [
+  propEq('id'), // node is the parent
+  containsParentInNode, // already has this parent
+  useWith(hasCycleAddingNodeParent, [identity, propId, identity]), // adds cycles in network
+];
 
-  if (arr1 == null || arr2 == null) {
-    return false;
-  }
+const invalidParent = curry((parentId, nodes, node) =>
+  any(validation => validation(parentId, node, nodes), addParentValidation));
 
-  if (arr1.length !== arr2.length) {
-    return false;
-  }
+const canAddParent = (state, action) =>
+  allPass([
+    isNodeFromPayloadId(action),
+    complement(invalidParent(pathPayloadParentId(action), state)),
+  ]);
 
-  for (let i = 0; i < arr1.length; i++) {
-    if (arr1[i] !== arr2[i]) {
-      return false;
-    }
-  }
+const changeParentStates = curry((parentId, nextStates, nodes, node) =>
+  evolve(
+    {
+      cpt: always(
+        updateNodeParentStatesInCpt(parentId, nextStates, nodes, node),
+      ),
+    },
+    node,
+  ));
 
-  return true;
-};
+const changeNodeStates = curry((nextStates, node) =>
+  evolve(
+    {
+      states: always(nextStates),
+      cpt: always(updateStatesInCpt(nextStates, node)),
+    },
+    node,
+  ));
 
-const buildWhens = (nodes, whens, acc = {}) => {
-  if (nodes.length === 0) {
-    whens.push(acc);
-    return;
-  }
+const changeParentId = curry((previousId, nextId, node) =>
+  evolve(
+    {
+      parents: always(changeNodeParentName(previousId, nextId, node)),
+      cpt: always(updateNodeParentIdInCpt(previousId, nextId, node)),
+    },
+    node,
+  ));
 
-  const node = nodes[0];
+const addParent = curry((parentId, nodes, node) =>
+  evolve(
+    {
+      parents: always(addNodeParent(parentId, node)),
+      cpt: always(addNodeParentInCpt(findNodeById(parentId, nodes), node)),
+    },
+    node,
+  ));
 
-  node.states.forEach((state) => {
-    buildWhens(nodes.slice(1), whens, {
-      ...acc,
-      [node.id]: state,
-    });
-  });
-};
+const removeParentFromNode = curry((parentId, nodes, node) =>
+  evolve(
+    {
+      parents: always(filterNodeParents(parentId, node)),
+      cpt: always(removeNodeParentInCpt(findNodeById(parentId, nodes), node)),
+    },
+    node,
+  ));
 
-const changeParentStates = (node, parentId, nextParentStates, nodes) => {
-  const parents = nodes
-    .filter(x => node.parents.includes(x.id))
-    .map(x => ({
-      ...x,
-      states: x.id === parentId ? nextParentStates : x.states,
-    }));
-
-  const whens = [];
-
-  buildWhens(parents, whens);
-
-  const newCpt = whens.map((when) => {
-    const newWhenKeys = Object.keys(when)
-      .sort((a, b) => a.localeCompare(b));
-
-    const oldRow = node.cpt.find((row) => {
-      const oldWhenKeys = Object.keys(row.when)
-        .sort((a, b) => a.localeCompare(b));
-
-      if (!arrayEqual(newWhenKeys, oldWhenKeys)) {
-        return false;
-      }
-
-      for (let i = 0; i < oldWhenKeys.length; i++) {
-        const state = oldWhenKeys[i];
-
-        if (when[state] !== row.when[state]) {
-          return false;
-        }
-      }
-
-      return true;
-    });
-
-    const newThen = oldRow != null ? (
-      oldRow.then
-    ) : (
-      node.states.reduce((acc, state) => ({
-        ...acc,
-        [state]: 1 / node.states.length,
-      }), {})
-    );
-
-    return {
-      when,
-      then: newThen,
-    };
-  });
-
-  return {
-    ...node,
-    cpt: newCpt,
-  };
-};
-
-const changeCptStates = (cpt, nextStates) => {
-  const newCpt = { ...cpt };
-  const previousStates = Object.keys(newCpt);
-
-  const newStates = nextStates.filter(x => !previousStates.some(y => y === x));
-
-  const deletedStates = previousStates.filter(x => !nextStates.some(y => y === x));
-
-  newStates.forEach((newState) => {
-    newCpt[newState] = 0;
-  });
-
-  let removedProbabilities = 0;
-
-  deletedStates.forEach((deletedState) => {
-    removedProbabilities += newCpt[deletedState];
-    delete newCpt[deletedState];
-  });
-
-  nextStates.forEach((state) => {
-    newCpt[state] += removedProbabilities / nextStates.length;
-  });
-
-  return newCpt;
-};
-
-const changeNodeStates = (node, nextStates) => {
-  let cpt;
-
-  if (node.parents.length === 0) {
-    cpt = changeCptStates(node.cpt, nextStates);
-  } else {
-    cpt = node.cpt.map(row => ({
-      ...row,
-      then: changeCptStates(row.then, nextStates),
-    }));
-  }
-
-  return {
-    ...node,
-    states: nextStates,
-    cpt,
-  };
-};
-
-const changeParentId = (node, previousId, nextId) => ({
-  ...node,
-  parents: node.parents.map(x => (x === previousId ? nextId : x)),
-  cpt: node.cpt.map((row) => {
-    const when = { ...row.when };
-
-    delete when[previousId];
-    when[nextId] = row.when[previousId];
-
-    return { ...row, when };
-  }),
+const newNode = applySpec({
+  id: propId,
+  states: propStates,
+  parents: always([]),
+  cpt: pipe(propStates, createCpt),
 });
-
-const hasCycles = (nodes, nodeToStartFrom, nodeToFindId) => {
-  for (let i = 0; i < nodeToStartFrom.parents.length; i++) {
-    const parentId = nodeToStartFrom.parents[i];
-
-    if (parentId === nodeToFindId) {
-      return true;
-    }
-
-    const parent = nodes.find(x => x.id === parentId);
-
-    if (hasCycles(nodes, parent, nodeToFindId)) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-const addParent = (node, parentId, nodes) => {
-  // Don't add the same node as a parent of itself
-  if (node.id === parentId) {
-    return node;
-  }
-
-  // Don't add if already parent
-  if (node.parents.some(x => x === parentId)) {
-    return node;
-  }
-
-  const parent = nodes.find(x => x.id === parentId);
-
-  // Don't add if adds cycles
-  if (hasCycles(nodes, parent, node.id)) {
-    return node;
-  }
-
-  let cpt = null;
-
-  if (node.parents.length === 0) {
-    cpt = parent.states.map(state => ({
-      when: { [parentId]: state },
-      then: { ...node.cpt },
-    }));
-  } else {
-    cpt = [];
-
-    parent.states.forEach((state) => {
-      node.cpt.forEach((oldRow) => {
-        cpt.push({
-          when: { ...oldRow.when, [parentId]: state },
-          then: { ...oldRow.then },
-        });
-      });
-    });
-  }
-
-  return {
-    ...node,
-    parents: [...node.parents, parentId],
-    cpt,
-  };
-};
-
-const removeParent = (node, parentId, nodes) => {
-  const newParents = node.parents.filter(x => x !== parentId);
-  const parent = nodes.find(x => x.id === parentId);
-
-  let cpt = null;
-
-  if (newParents.length === 0) {
-    cpt = node.cpt[0].then;
-  } else {
-    cpt = node.cpt
-      .filter(x => x.when[parentId] === parent.states[0])
-      .map((x) => {
-        const newRow = {
-          when: {},
-          then: x.then,
-        };
-
-        newParents.forEach((p) => { newRow.when[p] = x.when[p]; });
-
-        return newRow;
-      });
-  }
-
-  return {
-    ...node,
-    parents: newParents,
-    cpt,
-  };
-};
-
-const nodeReducer = (node, action) => {
-  if (node.parents.some(x => x === action.payload.id)) {
-    if (action.type === REMOVE_NODE) {
-      return removeParent(
-        node,
-        action.payload.id,
-        action.payload.nodes,
-      );
-    } if (action.type === CHANGE_NODE_ID) {
-      return changeParentId(
-        node,
-        action.payload.id,
-        action.payload.nextId,
-      );
-    } if (action.type === SAVE_EDITING_NODE_STATES) {
-      return changeParentStates(
-        node,
-        action.payload.id,
-        action.payload.states,
-        action.payload.nodes,
-      );
-    }
-  }
-
-  if (node.id !== action.payload.id) {
-    return node;
-  }
-
-  switch (action.type) {
-    case ADD_PARENT:
-      return addParent(node, action.payload.parentId, action.payload.nodes);
-    case REMOVE_PARENT:
-      return removeParent(node, action.payload.parentId, action.payload.nodes);
-    case SAVE_EDITING_NODE_STATES:
-      return changeNodeStates(node, action.payload.states);
-    case CHANGE_NODE_ID:
-      return {
-        ...node,
-        id: action.payload.nextId,
-      };
-    case SAVE_EDITING_NODE_CPT:
-      return {
-        ...node,
-        cpt: pathPayloadCpt(action),
-      };
-    case CHANGE_NODE_DESCRIPTION:
-      return {
-        ...node,
-        description: action.payload.description,
-      };
-    default:
-      return node;
-  }
-};
-
-const newNode = ({ id, states }) => {
-  const cpt = {};
-
-  states.forEach((state) => {
-    cpt[state] = 1 / states.length;
-  });
-
-  return ({
-    id,
-    states,
-    parents: [],
-    cpt,
-  });
-};
 
 export default (state = [], action) => {
   switch (action.type) {
     case NEW_NETWORK:
       return [];
     case LOAD_NETWORK:
-      return action.payload.state.nodes;
+      return pathPayloadStateNodes(action);
     case ADD_NODE:
-      return [
-        ...state,
-        newNode(action.payload),
-      ];
+      return append(newNode(action.payload), state);
     case REMOVE_NODE:
-      return state
-        .filter(node => node.id !== action.payload.id)
-        .map(node => nodeReducer(node, action));
+      return map(
+        removeParentFromNode(pathPayloadId(action), state),
+        removeNodeById(pathPayloadId(action), state),
+      );
     case ADD_PARENT:
+      return map(
+        ifElse(
+          canAddParent(state, action),
+          addParent(pathPayloadParentId(action), state),
+          identity,
+        ),
+        state,
+      );
+
     case REMOVE_PARENT:
-    case CHANGE_NODE_ID:
+      return map(
+        ifElse(
+          isNodeFromPayloadId(action),
+          removeParentFromNode(pathPayloadParentId(action), state),
+          identity,
+        ),
+        state,
+      );
+
     case SAVE_EDITING_NODE_CPT:
-    case SAVE_EDITING_NODE_STATES:
+      return map(
+        ifElse(
+          isNodeFromPayloadId(action),
+          assoc('cpt', pathPayloadCpt(action)),
+          identity,
+        ),
+        state,
+      );
+
     case CHANGE_NODE_DESCRIPTION:
-      return state.map(node => nodeReducer(node, action));
+      return map(
+        ifElse(
+          isNodeFromPayloadId(action),
+          assoc('description', pathPayloadDescription(action)),
+          identity,
+        ),
+        state,
+      );
+
+    case CHANGE_NODE_ID:
+      return map(
+        cond([
+          [isNodeFromPayloadId(action), assoc('id', pathPayloadNextId(action))],
+          [
+            containsParentInNode(pathPayloadId(action)),
+            changeParentId(pathPayloadId(action), pathPayloadNextId(action)),
+          ],
+          [T, identity],
+        ]),
+        state,
+      );
+
+    case SAVE_EDITING_NODE_STATES:
+      return map(
+        cond([
+          [
+            isNodeFromPayloadId(action),
+            changeNodeStates(pathPayloadStates(action)),
+          ],
+          [
+            containsParentInNode(pathPayloadId(action)),
+            changeParentStates(
+              pathPayloadId(action),
+              pathPayloadStates(action),
+              state,
+            ),
+          ],
+          [T, identity],
+        ]),
+        state,
+      );
+
     default:
       return state;
   }

--- a/src/reducers/nodes.test.js
+++ b/src/reducers/nodes.test.js
@@ -1,4 +1,3 @@
-import SimpleNetwork from 'json-templates/networks/simple.json';
 import NetworkChangeStatesInitial from 'json-templates/networks/change-states/initial.json';
 import NetworkChangeNodeStatesWithParents from 'json-templates/networks/change-states/node-with-parents.json';
 import NetworkChangeNodeStatesWithoutParents from 'json-templates/networks/change-states/node-without-parents.json';

--- a/src/reducers/nodes.test.js
+++ b/src/reducers/nodes.test.js
@@ -23,7 +23,6 @@ import {
 } from 'actions';
 import { SAVE_EDITING_NODE_CPT } from 'constants/editing-node-cpt';
 import { SAVE_EDITING_NODE_STATES } from 'constants/editing-node-states';
-import { clone } from 'ramda'; // some reducers are mutating the state :'(
 import reducer from './nodes';
 
 describe('Nodes Reducer', () => {
@@ -91,7 +90,7 @@ describe('Nodes Reducer', () => {
     it('removes node an updates cpt and parents from another nodes', () => {
       expect(reducer(NetworkRemoveNodeInitial, {
         type: REMOVE_NODE,
-        payload: { id, nodes: SimpleNetwork },
+        payload: { id },
       })).toEqual(NetworkRemoveNodeUpdated);
     });
   });
@@ -104,7 +103,7 @@ describe('Nodes Reducer', () => {
       it('returns state', () => {
         expect(reducer(NetworkChangeParentsNotConnected, {
           type: ADD_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsNotConnected },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsNotConnected);
       });
     });
@@ -116,7 +115,7 @@ describe('Nodes Reducer', () => {
       it('returns state', () => {
         expect(reducer(NetworkChangeParentsNotConnected, {
           type: ADD_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsNotConnected },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsNotConnected);
       });
     });
@@ -128,7 +127,7 @@ describe('Nodes Reducer', () => {
       it('returns state', () => {
         expect(reducer(NetworkChangeParentsNotConnected, {
           type: ADD_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsNotConnected },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsNotConnected);
       });
     });
@@ -140,7 +139,7 @@ describe('Nodes Reducer', () => {
       it('adds node in parents an updates cpt', () => {
         expect(reducer(NetworkChangeParentsNotConnected, {
           type: ADD_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsNotConnected },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsConnectedWithParents);
       });
     });
@@ -152,33 +151,33 @@ describe('Nodes Reducer', () => {
       it('adds node in parents an updates cpt', () => {
         expect(reducer(NetworkChangeParentsNotConnected, {
           type: ADD_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsNotConnected },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsConnectedWithoutParents);
       });
     });
   });
 
   describe('REMOVE_PARENT', () => {
-    describe('When removing connection with a node with parents', () => {
+    describe('When removing connection from a node with more than one parent', () => {
       const id = 'Node 3';
       const parentId = 'Node 4';
 
       it('removes node in parents an updates cpt', () => {
         expect(reducer(NetworkChangeParentsConnectedWithParents, {
           type: REMOVE_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsConnectedWithParents },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsNotConnected);
       });
     });
 
-    describe('When removing connection with a node without parents', () => {
+    describe('When removing connection from a node with only one parent', () => {
       const id = 'Node 1';
       const parentId = 'Node 4';
 
       it('removes node in parents an updates cpt', () => {
         expect(reducer(NetworkChangeParentsConnectedWithoutParents, {
           type: REMOVE_PARENT,
-          payload: { id, parentId, nodes: NetworkChangeParentsConnectedWithoutParents },
+          payload: { id, parentId },
         })).toEqual(NetworkChangeParentsNotConnected);
       });
     });
@@ -236,7 +235,7 @@ describe('Nodes Reducer', () => {
       it('returns state', () => {
         expect(reducer(NetworkChangeStatesInitial, {
           type: SAVE_EDITING_NODE_STATES,
-          payload: { id, states, nodes: clone(NetworkChangeStatesInitial) },
+          payload: { id, states },
         })).toEqual(NetworkChangeStatesInitial);
       });
     });
@@ -248,7 +247,7 @@ describe('Nodes Reducer', () => {
       it('updates node states and cpt', () => {
         expect(reducer(NetworkChangeStatesInitial, {
           type: SAVE_EDITING_NODE_STATES,
-          payload: { id, states, nodes: clone(NetworkChangeStatesInitial) },
+          payload: { id, states },
         })).toEqual(NetworkChangeNodeStatesWithParents);
       });
     });
@@ -260,7 +259,7 @@ describe('Nodes Reducer', () => {
       it('updates node states and cpt', () => {
         expect(reducer(NetworkChangeStatesInitial, {
           type: SAVE_EDITING_NODE_STATES,
-          payload: { id, states, nodes: clone(NetworkChangeStatesInitial) },
+          payload: { id, states },
         })).toEqual(NetworkChangeNodeStatesWithoutParents);
       });
     });

--- a/src/utils/combinations.js
+++ b/src/utils/combinations.js
@@ -1,30 +1,32 @@
 import {
-  assoc,
-  forEach,
-  head,
-  isEmpty,
-  tail,
+  append,
+  apply,
+  flatten,
+  flip,
+  length,
+  liftN,
+  map,
+  mergeAll,
+  objOf,
+  pipe,
+  reduce,
+  unapply,
 } from 'ramda';
 
-const createCombinations = (onCreateCombination, allNodes, acc = {}) => {
-  if (isEmpty(allNodes)) {
-    onCreateCombination(acc);
-  } else {
-    const { id, states } = head(allNodes);
+const applyAndFlatten = pipe(apply, flatten);
+const liftNFlipped = flip(liftN);
 
-    forEach((state) => {
-      createCombinations(onCreateCombination, tail(allNodes), assoc(id, state, acc));
-    }, states);
-  }
-};
+const createNodeIdAndStatesCombinations = ({ id, states }) => reduce(
+  (acc, state) => append(objOf(id, state), acc),
+  [],
+  states,
+);
+
+const liftCombinationsForArray = pipe(length, liftNFlipped(unapply(mergeAll)));
 
 export const createNodeCombinations = (nodes) => {
-  const combinations = [];
+  const combinations = map(createNodeIdAndStatesCombinations, nodes);
+  const liftCombinations = liftCombinationsForArray(combinations);
 
-  createCombinations(
-    combination => combinations.push(combination),
-    nodes,
-  );
-
-  return combinations;
+  return applyAndFlatten(liftCombinations, combinations);
 };

--- a/src/utils/combinations.js
+++ b/src/utils/combinations.js
@@ -14,7 +14,7 @@ import {
 } from 'ramda';
 
 const applyAndFlatten = pipe(apply, flatten);
-const liftNFlipped = flip(liftN);
+const flippedLiftN = flip(liftN);
 
 const createNodeIdAndStatesCombinations = ({ id, states }) => reduce(
   (acc, state) => append(objOf(id, state), acc),
@@ -22,7 +22,7 @@ const createNodeIdAndStatesCombinations = ({ id, states }) => reduce(
   states,
 );
 
-const liftCombinationsForArray = pipe(length, liftNFlipped(unapply(mergeAll)));
+const liftCombinationsForArray = pipe(length, flippedLiftN(unapply(mergeAll)));
 
 export const createNodeCombinations = (nodes) => {
   const combinations = map(createNodeIdAndStatesCombinations, nodes);

--- a/src/utils/combinations.js
+++ b/src/utils/combinations.js
@@ -1,0 +1,30 @@
+import {
+  assoc,
+  forEach,
+  head,
+  isEmpty,
+  tail,
+} from 'ramda';
+
+const createCombinations = (onCreateCombination, allNodes, acc = {}) => {
+  if (isEmpty(allNodes)) {
+    onCreateCombination(acc);
+  } else {
+    const { id, states } = head(allNodes);
+
+    forEach((state) => {
+      createCombinations(onCreateCombination, tail(allNodes), assoc(id, state, acc));
+    }, states);
+  }
+};
+
+export const createNodeCombinations = (nodes) => {
+  const combinations = [];
+
+  createCombinations(
+    combination => combinations.push(combination),
+    nodes,
+  );
+
+  return combinations;
+};

--- a/src/utils/combinations.test.js
+++ b/src/utils/combinations.test.js
@@ -1,0 +1,37 @@
+import { createNodeCombinations } from './combinations';
+
+describe('Combinations Utils', () => {
+  describe('createNodeCombinations', () => {
+    const nodes = [
+      {
+        id: 'Node 1',
+        states: ['True', 'False'],
+      },
+      {
+        id: 'Node 2',
+        states: ['True', 'False'],
+      },
+      {
+        id: 'Node 3',
+        states: ['State 1', 'State 2', 'State 3'],
+      },
+    ];
+
+    it('returns combinations between nodes id and states', () => {
+      expect(createNodeCombinations(nodes)).toEqual([
+        { 'Node 1': 'True', 'Node 2': 'True', 'Node 3': 'State 1' },
+        { 'Node 1': 'True', 'Node 2': 'True', 'Node 3': 'State 2' },
+        { 'Node 1': 'True', 'Node 2': 'True', 'Node 3': 'State 3' },
+        { 'Node 1': 'True', 'Node 2': 'False', 'Node 3': 'State 1' },
+        { 'Node 1': 'True', 'Node 2': 'False', 'Node 3': 'State 2' },
+        { 'Node 1': 'True', 'Node 2': 'False', 'Node 3': 'State 3' },
+        { 'Node 1': 'False', 'Node 2': 'True', 'Node 3': 'State 1' },
+        { 'Node 1': 'False', 'Node 2': 'True', 'Node 3': 'State 2' },
+        { 'Node 1': 'False', 'Node 2': 'True', 'Node 3': 'State 3' },
+        { 'Node 1': 'False', 'Node 2': 'False', 'Node 3': 'State 1' },
+        { 'Node 1': 'False', 'Node 2': 'False', 'Node 3': 'State 2' },
+        { 'Node 1': 'False', 'Node 2': 'False', 'Node 3': 'State 3' },
+      ]);
+    });
+  });
+});

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,0 +1,4 @@
+import float from 'float';
+import { NODE_CPT_PRECISION } from 'constants/node';
+
+export const roundValue = value => float.round(value, NODE_CPT_PRECISION);

--- a/src/utils/math.test.js
+++ b/src/utils/math.test.js
@@ -1,0 +1,9 @@
+import { roundValue } from './math';
+
+describe('Math Utils', () => {
+  describe('roundValue', () => {
+    it('rounds values with 8 of precision', () => {
+      expect(roundValue(1 / 3)).toBe(0.33333333);
+    });
+  });
+});

--- a/src/utils/node-cpt.js
+++ b/src/utils/node-cpt.js
@@ -72,27 +72,20 @@ const filterCptWhenByKeys = useWith(evolve, [pipe(pick, objOf('when'))]);
 const mapWhen = useWith(map, [filterCptWhenByKeys, identity]);
 const hasOnlyThisParent = useWith(all, [pipe(propId, equals), propParents]);
 const getValueForEachCpt = useWith(pipe(divide, roundValue), [identity, length]);
-const hasNoParent = useWith(complement(containsParentInNode), [
-  propId,
-  identity,
-]);
-
-const getMissingValueForEachCpt = converge(divide, [
-  pipe(nthArg0, getMissingValueFromCpt),
-  pipe(nthArg0, objectLenght),
-]);
+const hasNoParent = useWith(complement(containsParentInNode), [propId, identity]);
+const getMissingValueForEachCpt = converge(divide, [getMissingValueFromCpt, objectLenght]);
 
 const fixCptFloatingPoint = converge(
   over,
   [
-    pipe(nthArg0, getFirstKey, lensProp),
-    pipe(nthArg0, getMissingValueFromCpt, roundValue, add),
+    pipe(getFirstKey, lensProp),
+    pipe(getMissingValueFromCpt, roundValue, add),
     nthArg0,
   ],
 );
 
 const balanceCptValues = converge(pipe(map, fixCptFloatingPoint), [
-  pipe(nthArg0, getMissingValueForEachCpt, roundValue, add),
+  pipe(getMissingValueForEachCpt, roundValue, add),
   nthArg0,
 ]);
 
@@ -121,8 +114,8 @@ export const updateCptValue = (cpt, value, state, index) => {
 };
 
 export const createCpt = converge(pipe(map, fixCptFloatingPoint), [
-  pipe(nthArg0, getCptValueRounded, always),
-  pipe(nthArg0, invertObj),
+  pipe(getCptValueRounded, always),
+  invertObj,
 ]);
 
 const cptObjectToArray = (nodeParent, node) =>

--- a/src/utils/node-cpt.js
+++ b/src/utils/node-cpt.js
@@ -1,11 +1,117 @@
 import {
-  is,
+  T,
+  add,
+  all,
+  always,
+  applySpec,
   assoc,
-  set,
+  complement,
+  concat,
+  cond,
+  converge,
+  curry,
+  difference,
+  dissoc,
+  divide,
+  equals,
+  evolve,
+  flatten,
+  flip,
+  identity,
+  ifElse,
+  includes,
+  invertObj,
+  is,
+  head,
+  keys,
+  length,
   lensPath,
+  lensProp,
+  map,
+  mergeRight,
+  nthArg,
+  objOf,
+  omit,
+  over,
+  path,
+  pick,
+  pipe,
+  prop,
+  reject,
+  set,
+  subtract,
+  sum,
+  uniqBy,
+  useWith,
+  values,
 } from 'ramda';
+import { containsParentInNode, isNodeWithoutParents } from 'validations/node';
 
+import { createNodeCombinations } from './combinations';
+import { filterNodeParents } from './node-parents';
+import { findNodeById } from './node';
+import { roundValue } from './math';
+
+const propId = prop('id');
+const propCpt = prop('cpt');
+const propStates = prop('states');
+const propParents = prop('parents');
 const isArray = is(Array);
+const nthArg0 = nthArg(0);
+const nthArg1 = nthArg(1);
+const includesFlipped = flip(includes);
+const getCptValue = converge(divide, [always(1), length]);
+const getCptValueRounded = pipe(getCptValue, roundValue);
+const mapAndFlatten = pipe(map, flatten);
+const uniqByWhen = uniqBy(prop('when'));
+const objectLenght = pipe(keys, length);
+const sumValues = pipe(values, sum);
+const getFirstKey = pipe(keys, head);
+const getMissingValueFromCpt = pipe(sumValues, subtract(1));
+const filterCptWhenByKeys = useWith(evolve, [pipe(pick, objOf('when'))]);
+const mapWhen = useWith(map, [filterCptWhenByKeys, identity]);
+const hasOnlyThisParent = useWith(all, [pipe(propId, equals), propParents]);
+const getValueForEachCpt = useWith(pipe(divide, roundValue), [identity, length]);
+const hasNoParent = useWith(complement(containsParentInNode), [
+  propId,
+  identity,
+]);
+
+const getMissingValueForEachCpt = converge(divide, [
+  pipe(nthArg0, getMissingValueFromCpt),
+  pipe(nthArg0, objectLenght),
+]);
+
+const fixCptFloatingPoint = converge(
+  over,
+  [
+    pipe(nthArg0, getFirstKey, lensProp),
+    pipe(nthArg0, getMissingValueFromCpt, roundValue, add),
+    nthArg0,
+  ],
+);
+
+const balanceCptValues = converge(pipe(map, fixCptFloatingPoint), [
+  pipe(nthArg0, getMissingValueForEachCpt, roundValue, add),
+  nthArg0,
+]);
+
+const addKeyAndValueInWhen = (key, value) =>
+  set(lensPath(['when', key]), value);
+
+const addNewStatesInCptWithValue = (value, states, cpt) =>
+  mergeRight(
+    cpt,
+    map(always(getValueForEachCpt(value, states)), invertObj(states)),
+  );
+
+const getDiffStates = applySpec({
+  deletedStates: flip(difference),
+  newStates: difference,
+});
+
+const renamePropKey = curry((oldKey, newKey, obj) =>
+  assoc(newKey, prop(oldKey, obj), dissoc(oldKey, obj)));
 
 export const updateCptValue = (cpt, value, state, index) => {
   if (isArray(cpt)) {
@@ -13,3 +119,121 @@ export const updateCptValue = (cpt, value, state, index) => {
   }
   return assoc(state, value, cpt);
 };
+
+export const createCpt = converge(pipe(map, fixCptFloatingPoint), [
+  pipe(nthArg0, getCptValueRounded, always),
+  pipe(nthArg0, invertObj),
+]);
+
+const cptObjectToArray = (nodeParent, node) =>
+  map(
+    state => ({
+      when: objOf(propId(nodeParent), state),
+      then: propCpt(node),
+    }),
+    propStates(nodeParent),
+  );
+
+const addCptArrayItem = (nodeParent, node) => {
+  const id = propId(nodeParent);
+
+  return mapAndFlatten(
+    newState => map(addKeyAndValueInWhen(id, newState), propCpt(node)),
+    propStates(nodeParent),
+  );
+};
+
+export const addNodeParentInCpt = ifElse(
+  pipe(nthArg1, isNodeWithoutParents),
+  cptObjectToArray,
+  addCptArrayItem,
+);
+
+const removeParentInCptWhenNodeHasOneParent = path(['cpt', 0, 'then']);
+
+const removeParentInCptWhenNodeHasMoreThanOneParent = (nodeParent, node) =>
+  uniqByWhen(
+    mapWhen(filterNodeParents(propId(nodeParent), node), propCpt(node)),
+  );
+
+export const removeNodeParentInCpt = cond([
+  [hasNoParent, pipe(nthArg1, propCpt)],
+  [hasOnlyThisParent, pipe(nthArg1, removeParentInCptWhenNodeHasOneParent)],
+  [T, removeParentInCptWhenNodeHasMoreThanOneParent],
+]);
+
+const changeCptStates = curry((nextStates, cpt) => {
+  const { deletedStates, newStates } = getDiffStates(nextStates, keys(cpt));
+  const valueFromDeletedStates = roundValue(sumValues(pick(deletedStates, cpt)));
+
+  return balanceCptValues(
+    omit(
+      deletedStates,
+      addNewStatesInCptWithValue(valueFromDeletedStates, newStates, cpt),
+    ),
+  );
+});
+
+const updateStatesInCptObject = useWith(changeCptStates, [identity, propCpt]);
+
+const updateStatesInCptArray = (nextStates, node) =>
+  map(
+    evolve({
+      then: changeCptStates(nextStates),
+    }),
+    propCpt(node),
+  );
+
+export const updateStatesInCpt = ifElse(
+  pipe(nthArg1, isNodeWithoutParents),
+  updateStatesInCptObject,
+  updateStatesInCptArray,
+);
+
+export const updateNodeParentIdInCpt = (nodeId, nextId, node) =>
+  map(
+    evolve({
+      when: renamePropKey(nodeId, nextId),
+    }),
+    propCpt(node),
+  );
+
+const createWhensForNodeWithStates = (parentId, newStates, nodes, node) => {
+  const nodeParents = map(id => findNodeById(id, nodes), node.parents);
+  const parents = map(
+    ({ id, states }) => ({
+      id,
+      states: equals(id, parentId) ? newStates : states,
+    }),
+    nodeParents,
+  );
+
+  return createNodeCombinations(parents);
+};
+
+const removeCptsForNodeWithStates = (parentId, deletedStates, node) =>
+  reject(
+    pipe(path(['when', parentId]), includesFlipped(deletedStates)),
+    propCpt(node),
+  );
+
+const createCptsForNodeWithStates = (parentId, newStates, nodes, node) =>
+  map(
+    pipe(objOf('when'), assoc('then', createCpt(propStates(node)))),
+    createWhensForNodeWithStates(parentId, newStates, nodes, node),
+  );
+
+export const updateNodeParentStatesInCpt = curry(
+  (parentId, nextStates, nodes, node) => {
+    const nodeParent = findNodeById(parentId, nodes);
+    const { deletedStates, newStates } = getDiffStates(
+      nextStates,
+      propStates(nodeParent),
+    );
+
+    return concat(
+      removeCptsForNodeWithStates(parentId, deletedStates, node),
+      createCptsForNodeWithStates(parentId, newStates, nodes, node),
+    );
+  },
+);

--- a/src/utils/node-cpt.test.js
+++ b/src/utils/node-cpt.test.js
@@ -1,8 +1,15 @@
+import SimpleNetwork from 'json-templates/networks/simple.json';
 import {
+  addNodeParentInCpt,
+  createCpt,
+  removeNodeParentInCpt,
   updateCptValue,
+  updateNodeParentIdInCpt,
+  updateNodeParentStatesInCpt,
+  updateStatesInCpt,
 } from './node-cpt';
 
-describe('Node Validations', () => {
+describe('Node Cpt Utils', () => {
   describe('updateCptValue', () => {
     describe('When cpt is a object', () => {
       const cpt = {
@@ -59,6 +66,545 @@ describe('Node Validations', () => {
               T: 0.5,
               F: 0.3,
             },
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('createCpt', () => {
+    describe('When node has two states', () => {
+      const states = ['True', 'False'];
+
+      it('returns a object with all keys with the same value', () => {
+        expect(createCpt(states)).toEqual({
+          True: 0.5,
+          False: 0.5,
+        });
+      });
+    });
+
+    describe('When node has three states (floating point)', () => {
+      const states = ['State_1', 'State_2', 'State_3'];
+
+      it('returns a object with all keys value truncated and the first one with the missing value', () => {
+        expect(createCpt(states)).toEqual({
+          State_1: 0.33333334,
+          State_2: 0.33333333,
+          State_3: 0.33333333,
+        });
+      });
+    });
+  });
+
+  describe('addNodeParentInCpt', () => {
+    describe('When node has no parents', () => {
+      const node = {
+        id: 'Node 1',
+        parents: [],
+        cpt: {
+          True: 0.5,
+          False: 0.5,
+        },
+      };
+      const nodeParent = {
+        id: 'Node 2',
+        states: ['True', 'False'],
+      };
+
+      it('returns a cpt array', () => {
+        expect(addNodeParentInCpt(nodeParent, node)).toEqual([
+          {
+            then: { False: 0.5, True: 0.5 },
+            when: { 'Node 2': 'True' },
+          }, {
+            then: { False: 0.5, True: 0.5 },
+            when: { 'Node 2': 'False' },
+          },
+        ]);
+      });
+    });
+
+    describe('When node has parents', () => {
+      const node = {
+        id: 'Node 3',
+        cpt: [
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ],
+      };
+      const nodeParent = {
+        id: 'Node 4',
+        states: ['True', 'False'],
+
+      };
+
+      it('returns cpt array with news items', () => {
+        expect(addNodeParentInCpt(nodeParent, node)).toEqual([
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('removeNodeParentInCpt', () => {
+    describe('When node doens not have the parent', () => {
+      const node = {
+        id: 'Node 3',
+        parents: [],
+        states: ['True', 'False'],
+        cpt: { True: 0.5, False: 0.5 },
+      };
+      const nodeParent = {
+        id: 'Node 1',
+        parents: [],
+        states: ['True', 'False'],
+        cpt: { 'State 1': 0.5, 'State 2': 0.5 },
+      };
+
+      it('returns cpt', () => {
+        expect(removeNodeParentInCpt(nodeParent, node)).toEqual({ True: 0.5, False: 0.5 });
+      });
+    });
+
+    describe('When node has only this parent', () => {
+      const nodeParent = {
+        id: 'Node 4',
+      };
+      const node = {
+        parents: ['Node 4'],
+        cpt: [
+          {
+            when: { 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ],
+      };
+
+      it('returns the first "then" as cpt', () => {
+        expect(removeNodeParentInCpt(nodeParent, node)).toEqual({
+          True: 0.5,
+          False: 0.5,
+        });
+      });
+    });
+
+    describe('When node has not only this parent', () => {
+      const nodeParent = {
+        id: 'Node 4',
+        states: ['True', 'False'],
+      };
+      const node = {
+        parents: ['Node 1', 'Node 2', 'Node 4'],
+        cpt: [
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False', 'Node 4': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False', 'Node 4': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ],
+      };
+
+      it('removes parent node from "when"', () => {
+        expect(removeNodeParentInCpt(nodeParent, node)).toEqual([
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('updateStatesInCpt', () => {
+    describe('When node has no parents', () => {
+      const node = {
+        id: 'Node 1',
+        states: [
+          'True',
+          'False',
+        ],
+        parents: [],
+        cpt: {
+          State_1: 0.25,
+          State_2: 0.25,
+          State_3: 0.25,
+          State_4: 0.25,
+        },
+      };
+
+      describe('and is adding a new state', () => {
+        const states = ['State_1', 'State_2', 'State_3', 'State_4', 'State_5'];
+
+        it('adds new state with zero as value', () => {
+          expect(updateStatesInCpt(states, node)).toEqual({
+            State_1: 0.25,
+            State_2: 0.25,
+            State_3: 0.25,
+            State_4: 0.25,
+            State_5: 0,
+          });
+        });
+      });
+
+      describe('and is removing a state', () => {
+        const states = ['State_1', 'State_2'];
+
+        it('removes the states and balance the cpt values', () => {
+          expect(updateStatesInCpt(states, node)).toEqual({
+            State_1: 0.5,
+            State_2: 0.5,
+          });
+        });
+      });
+
+      describe('and is adding and removing states', () => {
+        const states = ['State_1', 'State_2', 'State_3', 'State_New'];
+
+        it('removes/adds the states and adds the removed value in new states', () => {
+          expect(updateStatesInCpt(states, node)).toEqual({
+            State_1: 0.25,
+            State_2: 0.25,
+            State_3: 0.25,
+            State_New: 0.25,
+          });
+        });
+      });
+    });
+
+    describe('When node has parents', () => {
+      const node = {
+        id: 'Node 3',
+        states: ['True', 'False'],
+        parents: ['Node 2', 'Node 1'],
+        cpt: [
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'True', 'Node 1': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 2': 'False', 'Node 1': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ],
+      };
+
+      describe('and is adding a new state', () => {
+        const states = ['True', 'False', 'New State'];
+
+        it('adds new state with zero as value', () => {
+          expect(updateStatesInCpt(states, node)).toEqual([
+            {
+              when: { 'Node 1': 'True', 'Node 2': 'True' },
+              then: { 'New State': 0, True: 0.5, False: 0.5 },
+            },
+            {
+              when: { 'Node 1': 'True', 'Node 2': 'False' },
+              then: { 'New State': 0, True: 0.5, False: 0.5 },
+            },
+            {
+              when: { 'Node 1': 'False', 'Node 2': 'True' },
+              then: { 'New State': 0, True: 0.5, False: 0.5 },
+            },
+            {
+              when: { 'Node 1': 'False', 'Node 2': 'False' },
+              then: { 'New State': 0, True: 0.5, False: 0.5 },
+            },
+          ]);
+        });
+      });
+
+      describe('and is removing a state', () => {
+        const states = ['True'];
+
+        it('removes the state and balance the cpt values', () => {
+          expect(updateStatesInCpt(states, node)).toEqual([
+            {
+              when: { 'Node 1': 'True', 'Node 2': 'True' },
+              then: { True: 1 },
+            },
+            {
+              when: { 'Node 1': 'True', 'Node 2': 'False' },
+              then: { True: 1 },
+            },
+            {
+              when: { 'Node 1': 'False', 'Node 2': 'True' },
+              then: { True: 1 },
+            },
+            {
+              when: { 'Node 1': 'False', 'Node 2': 'False' },
+              then: { True: 1 },
+            },
+          ]);
+        });
+      });
+
+      describe('and is adding and removing states', () => {
+        const states = ['True', 'New State'];
+
+        it('removes/adds the states and adds the removed value in new states', () => {
+          expect(updateStatesInCpt(states, node)).toEqual([
+            {
+              when: { 'Node 1': 'True', 'Node 2': 'True' },
+              then: { 'New State': 0.5, True: 0.5 },
+            },
+            {
+              when: { 'Node 1': 'True', 'Node 2': 'False' },
+              then: { 'New State': 0.5, True: 0.5 },
+            },
+            {
+              when: { 'Node 1': 'False', 'Node 2': 'True' },
+              then: { 'New State': 0.5, True: 0.5 },
+            },
+            {
+              when: { 'Node 1': 'False', 'Node 2': 'False' },
+              then: { 'New State': 0.5, True: 0.5 },
+            },
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('updateNodeParentIdInCpt', () => {
+    const id = 'Node 2';
+    const nextId = 'New ID';
+    const node = {
+      id: 'Node 3',
+      cpt: [
+        {
+          when: { 'Node 2': 'True', 'Node 1': 'True' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'Node 2': 'False', 'Node 1': 'True' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'Node 2': 'True', 'Node 1': 'False' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'Node 2': 'False', 'Node 1': 'False' },
+          then: { True: 0.5, False: 0.5 },
+        },
+      ],
+    };
+
+    it('updates "when" with new id', () => {
+      expect(updateNodeParentIdInCpt(id, nextId, node)).toEqual([
+        {
+          when: { 'New ID': 'True', 'Node 1': 'True' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'New ID': 'False', 'Node 1': 'True' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'New ID': 'True', 'Node 1': 'False' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'New ID': 'False', 'Node 1': 'False' },
+          then: { True: 0.5, False: 0.5 },
+        },
+      ]);
+    });
+  });
+
+  describe('updateNodeParentStatesInCpt', () => {
+    const parentId = 'Node 1';
+    const node = {
+      id: 'Node 3',
+      states: ['True', 'False'],
+      parents: ['Node 2', 'Node 1'],
+      cpt: [
+        {
+          when: { 'Node 1': 'True', 'Node 2': 'True' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'Node 1': 'True', 'Node 2': 'False' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'Node 1': 'False', 'Node 2': 'True' },
+          then: { True: 0.5, False: 0.5 },
+        },
+        {
+          when: { 'Node 1': 'False', 'Node 2': 'False' },
+          then: { True: 0.5, False: 0.5 },
+        },
+      ],
+    };
+
+    describe('When is adding a new state', () => {
+      const nextStates = ['True', 'False', 'New State'];
+
+      it('adds new cpt item with new states', () => {
+        expect(updateNodeParentStatesInCpt(parentId, nextStates, SimpleNetwork, node)).toEqual([
+          {
+            when: { 'Node 1': 'True', 'Node 2': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'True', 'Node 2': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'False', 'Node 2': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'False', 'Node 2': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'New State', 'Node 2': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'New State', 'Node 2': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ]);
+      });
+    });
+
+    describe('When is removing a state', () => {
+      const nextStates = ['True'];
+
+      it('removes cpt items with removed states', () => {
+        expect(updateNodeParentStatesInCpt(parentId, nextStates, SimpleNetwork, node)).toEqual([
+          {
+            when: { 'Node 1': 'True', 'Node 2': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'True', 'Node 2': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+        ]);
+      });
+    });
+
+    describe('When is adding and removing states', () => {
+      const nextStates = ['True', 'New State'];
+
+      it('removes/adds cpt items', () => {
+        expect(updateNodeParentStatesInCpt(parentId, nextStates, SimpleNetwork, node)).toEqual([
+          {
+            when: { 'Node 1': 'True', 'Node 2': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'True', 'Node 2': 'False' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'New State', 'Node 2': 'True' },
+            then: { True: 0.5, False: 0.5 },
+          },
+          {
+            when: { 'Node 1': 'New State', 'Node 2': 'False' },
+            then: { True: 0.5, False: 0.5 },
           },
         ]);
       });

--- a/src/utils/node-parents.js
+++ b/src/utils/node-parents.js
@@ -1,0 +1,29 @@
+import {
+  always,
+  append,
+  equals,
+  identity,
+  map,
+  prop,
+  reject,
+  useWith,
+  when,
+} from 'ramda';
+
+const propParents = prop('parents');
+
+export const filterNodeParents = useWith(
+  reject,
+  [equals, propParents],
+);
+
+export const addNodeParent = useWith(
+  append,
+  [identity, propParents],
+);
+
+export const changeNodeParentName = (parentId, nextParentId, node) =>
+  map(
+    when(equals(parentId), always(nextParentId)),
+    propParents(node),
+  );

--- a/src/utils/node-parents.test.js
+++ b/src/utils/node-parents.test.js
@@ -1,0 +1,42 @@
+import { filterNodeParents, addNodeParent, changeNodeParentName } from './node-parents';
+
+describe('Node Parents Utils', () => {
+  describe('filterNodeParents', () => {
+    const parentId = 'Node 4';
+    const node = {
+      id: 'Node 1',
+      parents: ['Node 2', 'Node 3', 'Node 4'],
+    };
+
+    it('returns parents without parentId', () => {
+      expect(filterNodeParents(parentId, node)).toEqual([
+        'Node 2', 'Node 3',
+      ]);
+    });
+  });
+
+  describe('addNodeParent', () => {
+    const parentId = 'Node 4';
+    const node = {
+      id: 'Node 1',
+      parents: ['Node 2', 'Node 3'],
+    };
+
+    it('returns parents with new parentId', () => {
+      expect(addNodeParent(parentId, node)).toEqual(['Node 2', 'Node 3', 'Node 4']);
+    });
+  });
+
+  describe('changeNodeParentName', () => {
+    const parentId = 'Node 3';
+    const nextParentId = 'New Node';
+    const node = {
+      id: 'Node 1',
+      parents: ['Node 2', 'Node 3', 'Node 4'],
+    };
+
+    it('replaces old id for the new one', () => {
+      expect(changeNodeParentName(parentId, nextParentId, node)).toEqual(['Node 2', 'New Node', 'Node 4']);
+    });
+  });
+});

--- a/src/utils/node.js
+++ b/src/utils/node.js
@@ -1,0 +1,25 @@
+import {
+  find,
+  findIndex,
+  identity,
+  propEq,
+  reject,
+  useWith,
+} from 'ramda';
+
+const propId = propEq('id');
+
+export const findNodeById = useWith(
+  find,
+  [propId, identity],
+);
+
+export const findIndexNodeById = useWith(
+  findIndex,
+  [propId, identity],
+);
+
+export const removeNodeById = useWith(
+  reject,
+  [propId, identity],
+);

--- a/src/utils/node.test.js
+++ b/src/utils/node.test.js
@@ -1,0 +1,64 @@
+import SimpleNetwork from 'json-templates/networks/simple.json';
+import { findNodeById, removeNodeById, findIndexNodeById } from './node';
+
+describe('Node Utils', () => {
+  describe('findNodeById', () => {
+    const id = 'Node 2';
+
+    it('returns node with id', () => {
+      expect(findNodeById(id, SimpleNetwork)).toEqual({
+        id: 'Node 2',
+        states: [
+          'True',
+          'False',
+        ],
+        parents: [],
+        cpt: {
+          True: 0.5,
+          False: 0.5,
+        },
+      });
+    });
+  });
+
+  describe('findIndexNodeById', () => {
+    const id = 'Node 2';
+
+    it('returns index from node with id', () => {
+      expect(findIndexNodeById(id, SimpleNetwork)).toBe(1);
+    });
+  });
+
+  describe('removeNodeById', () => {
+    const id = 'Node 3';
+
+    it('removes node from node array by id', () => {
+      expect(removeNodeById(id, SimpleNetwork)).toEqual([
+        {
+          id: 'Node 1',
+          states: [
+            'True',
+            'False',
+          ],
+          parents: [],
+          cpt: {
+            True: 0.5,
+            False: 0.5,
+          },
+        },
+        {
+          id: 'Node 2',
+          states: [
+            'True',
+            'False',
+          ],
+          parents: [],
+          cpt: {
+            True: 0.5,
+            False: 0.5,
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/src/validations/network.js
+++ b/src/validations/network.js
@@ -1,30 +1,35 @@
 import {
-  map,
-  isEmpty,
-  reject,
+  any,
+  append,
+  complement,
   equals,
   filter,
+  identity,
+  isEmpty,
+  lensPath,
+  map,
+  over,
+  pick,
   pipe,
   prop,
-  pick,
-  includes,
-  any,
-  complement,
+  reject,
+  useWith,
 } from 'ramda';
+import { findIndexNodeById } from 'utils/node';
+import { containsParentInNode } from './node';
 
 const isNotEmpty = complement(isEmpty);
 const propId = prop('id');
 const propParents = prop('parents');
 const mapIdAndParents = map(pick(['id', 'parents']));
-
 const hasEmptyParents = pipe(propParents, isEmpty);
 const filterEmptyParentNodes = filter(hasEmptyParents);
 const anyNodesHasNoEmptyParents = any(complement(hasEmptyParents));
 
-const hasParentsWithId = id => pipe(propParents, includes(id));
-
-const getNodesWithParents = (parentId, nodes) =>
-  filter(hasParentsWithId(parentId), nodes);
+const getNodesWithParents = useWith(
+  filter,
+  [containsParentInNode, identity],
+);
 
 const removeParentFromNode = (node, parentId) => {
   node.parents = reject(equals(parentId), propParents(node));
@@ -52,3 +57,12 @@ export const hasCycles = (nodes) => {
 
   return anyNodesHasNoEmptyParents(clonedNodes);
 };
+
+const addNodeParentInNodes = (id, parentId, nodes) => over(
+  lensPath([findIndexNodeById(id, nodes), 'parents']),
+  append(parentId),
+  nodes,
+);
+
+export const hasCycleAddingNodeParent = (parentId, nodeId, nodes) =>
+  hasCycles(addNodeParentInNodes(nodeId, parentId, nodes));

--- a/src/validations/network.test.js
+++ b/src/validations/network.test.js
@@ -1,6 +1,6 @@
 import SimpleNetwork from 'json-templates/networks/simple.json';
 import CyclicNetwork from 'json-templates/networks/cyclic.json';
-import { hasCycles } from './network';
+import { hasCycles, hasCycleAddingNodeParent } from './network';
 
 describe('Network Utils', () => {
   describe('hasCycles', () => {
@@ -13,6 +13,26 @@ describe('Network Utils', () => {
     describe('When network has not cycles', () => {
       it('returns falsy', () => {
         expect(hasCycles(SimpleNetwork)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('hasCycleAddingNodeParent', () => {
+    describe('When connecting two nodes will create a cyclic network', () => {
+      const parentId = 'Node 3';
+      const nodeId = 'Node 1';
+
+      it('returns truthy', () => {
+        expect(hasCycleAddingNodeParent(parentId, nodeId, SimpleNetwork)).toBeTruthy();
+      });
+    });
+
+    describe('When connecting two nodes will not create a cyclic network', () => {
+      const parentId = 'Node 2';
+      const nodeId = 'Node 1';
+
+      it('returns falsy', () => {
+        expect(hasCycleAddingNodeParent(parentId, nodeId, SimpleNetwork)).toBeFalsy();
       });
     });
   });

--- a/src/validations/node.js
+++ b/src/validations/node.js
@@ -1,18 +1,21 @@
 import {
-  has,
-  is,
+  all,
   allPass,
-  pipe,
-  prop,
-  not,
-  values,
-  sum,
+  any,
   compose,
   equals,
-  all,
+  has,
+  ifElse,
+  is,
+  isEmpty,
+  not,
+  pipe,
+  prop,
+  sum,
+  useWith,
+  values,
 } from 'ramda';
-import float from 'float';
-import { NODE_CPT_PRECISION } from 'constants/node';
+import { roundValue } from 'utils/math';
 
 const isArray = is(Array);
 const isObject = is(Object);
@@ -30,22 +33,20 @@ export const hasConnections = allPass([
   propIsObject('linkedNode'),
 ]);
 
-export const hasStates = allPass([
-  has('states'),
-  propIsArray('states'),
-]);
+export const hasStates = allPass([has('states'), propIsArray('states')]);
 
 export const hasDescription = ({ showDescription, description }) =>
   Boolean(showDescription && description);
 
-const formatFloatValue = value => float.round(value, NODE_CPT_PRECISION);
-
-const isSumValuesEqualsOne = pipe(sumValues, formatFloatValue, equalsOne);
+const isSumValuesEqualsOne = pipe(sumValues, roundValue, equalsOne);
 const isAllThenSumValuesEqualsOne = all(pipe(propThen, isSumValuesEqualsOne));
 
-export const isNodeCptValid = (cpt) => {
-  if (isArray(cpt)) {
-    return isAllThenSumValuesEqualsOne(cpt);
-  }
-  return isSumValuesEqualsOne(cpt);
-};
+export const isNodeCptValid = ifElse(
+  isArray,
+  isAllThenSumValuesEqualsOne,
+  isSumValuesEqualsOne,
+);
+
+export const isNodeWithoutParents = pipe(prop('parents'), isEmpty);
+
+export const containsParentInNode = useWith(any, [equals, prop('parents')]);

--- a/src/validations/node.test.js
+++ b/src/validations/node.test.js
@@ -1,8 +1,10 @@
 import {
+  containsParentInNode,
   hasConnections,
   hasDescription,
   hasStates,
   isNodeCptValid,
+  isNodeWithoutParents,
 } from './node';
 
 describe('Node Validations', () => {
@@ -31,7 +33,7 @@ describe('Node Validations', () => {
       });
 
       it('when has not "linkedNode" prop', () => {
-        expect(hasConnections({ })).toBeFalsy();
+        expect(hasConnections({})).toBeFalsy();
       });
     });
   });
@@ -64,7 +66,7 @@ describe('Node Validations', () => {
       });
 
       it('when has not "description" prop and no "showDescription" prop', () => {
-        expect(hasDescription({ })).toBeFalsy();
+        expect(hasDescription({})).toBeFalsy();
       });
     });
   });
@@ -94,7 +96,7 @@ describe('Node Validations', () => {
       });
 
       it('when has not "states" prop', () => {
-        expect(hasStates({ })).toBeFalsy();
+        expect(hasStates({})).toBeFalsy();
       });
     });
   });
@@ -187,6 +189,66 @@ describe('Node Validations', () => {
         it('returns falsy', () => {
           expect(isNodeCptValid(cpt)).toBeFalsy();
         });
+      });
+    });
+  });
+
+  describe('isNodeWithoutParents', () => {
+    describe('When node has no parents', () => {
+      const node = {
+        parents: [],
+      };
+
+      it('returns truthy', () => {
+        expect(isNodeWithoutParents(node)).toBeTruthy();
+      });
+    });
+
+    describe('When node has parents', () => {
+      const node = {
+        parents: ['True', 'False'],
+      };
+
+      it('returns falsy', () => {
+        expect(isNodeWithoutParents(node)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('containsParentInNode', () => {
+    describe('When node has no parents', () => {
+      const parentId = 'Node 2';
+      const node = {
+        id: 'Node 1',
+        parents: [],
+      };
+
+      it('returns falsy', () => {
+        expect(containsParentInNode(parentId, node)).toBeFalsy();
+      });
+    });
+
+    describe('When parent is not in node parents', () => {
+      const parentId = 'Node 2';
+      const node = {
+        id: 'Node 1',
+        parents: ['Node 3', 'Node 4'],
+      };
+
+      it('returns falsy', () => {
+        expect(containsParentInNode(parentId, node)).toBeFalsy();
+      });
+    });
+
+    describe('When parent is in node parents', () => {
+      const parentId = 'Node 2';
+      const node = {
+        id: 'Node 1',
+        parents: ['Node 2', 'Node 3'],
+      };
+
+      it('returns truthy', () => {
+        expect(containsParentInNode(parentId, node)).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
#### What does this PR do?

Refactor node reducer.
I've extracted this reduce logic to other files like `utils/node-cpt`, `utils/combinations`, `utils/node-parents`, `validations/node`...
Also, I fix the floating-point error when, for example, the user creates a node with three states:
```
// Before
{
  State1: 0.3333333333333333,
  State2: 0.3333333333333333,
  State3: 0.3333333333333333,
}
// Now
{
  State1: 0.33333334,
  State2: 0.33333333,
  State3: 0.33333333,
}
```
Fixed to the bug when the user removes and creates new states on an existing node:
```js
// Original CPT
 {
  True: 0.5,
  False: 0.5
}
// Changing states from ['True', 'False'] to ['True', 'New State']

// Before
 {
  True: 0.75,
  'New State': 0.25
}
// Now
{
  True: 0.5,
  'New State': 0.5
}
```

#### Where should the reviewer start?

`src/reducers/nodes.js`

#### What testing has been done on this PR?

Tested manually the app and `yarn test:unit`

#### How should this be manually tested?

`yarn test:unit`

#### Any background context you want to provide?

NA

#### What are the relevant issues?

#55 

#### Screenshots (if appropriate)

NA
